### PR TITLE
Firebaseで認証/認可の機能を作成した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+## env ##
+config/

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
 
+		<dependency>
+			<groupId>com.google.firebase</groupId>
+			<artifactId>firebase-admin</artifactId>
+			<version>9.0.0</version>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
 			<artifactId>firebase-admin</artifactId>
 			<version>9.0.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>javax.ws.rs-api</artifactId>
+			<version>2.1.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/example/nakayoshi/CertificationFilter.java
+++ b/src/main/java/com/example/nakayoshi/CertificationFilter.java
@@ -22,7 +22,6 @@ public class CertificationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
-    // リクエストヘッダからJWTを取り出す
     String sessionToken = getSessionToken(request);
 
     try {
@@ -31,13 +30,11 @@ public class CertificationFilter extends OncePerRequestFilter {
 
       filterChain.doFilter(request, response);
 
-    // 検証に失敗
     } catch (Exception e) {
        
     }
   }
 
-  // リクエストヘッダからトークンを取得
   private String getSessionToken(HttpServletRequest request) {
     Cookie[] cookies = request.getCookies();
 

--- a/src/main/java/com/example/nakayoshi/CertificationFilter.java
+++ b/src/main/java/com/example/nakayoshi/CertificationFilter.java
@@ -1,0 +1,62 @@
+package com.example.nakayoshi;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.Cookie;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.google.firebase.auth.FirebaseAuth;
+
+@Component
+public class CertificationFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    // リクエストヘッダからJWTを取り出す
+    String sessionToken = getSessionToken(request);
+
+    try {
+      // JWTを検証
+      FirebaseAuth.getInstance().verifySessionCookie(sessionToken, true);
+
+      filterChain.doFilter(request, response);
+
+    // 検証に失敗
+    } catch (Exception e) {
+       
+    }
+  }
+
+  // リクエストヘッダからトークンを取得
+  private String getSessionToken(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+
+    String sessionToken = ""; 
+    for(int i = 0; i < cookies.length; i++){
+      if(cookies[i].getName().equals("session")){
+        sessionToken = cookies[i].getValue(); 
+      }
+    }
+    return sessionToken;
+  }
+
+  @Bean
+  public FilterRegistrationBean<CertificationFilter> filter(){
+      FilterRegistrationBean<CertificationFilter> bean = new FilterRegistrationBean<>();
+
+      bean.setFilter(new CertificationFilter());
+      bean.addUrlPatterns("");
+
+      return bean;
+  } 
+}

--- a/src/main/java/com/example/nakayoshi/LoginController.java
+++ b/src/main/java/com/example/nakayoshi/LoginController.java
@@ -1,0 +1,65 @@
+package com.example.nakayoshi;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.SessionCookieOptions;
+
+@Controller
+public class LoginController {
+
+  @RequestMapping(value = {"/", "/login"})
+  public String login(){
+    return "login";
+  }
+
+  @RequestMapping("/auth")
+  @ResponseBody
+  public String resCookie(HttpServletRequest request, HttpServletResponse response) throws FirebaseAuthException{
+      String idToken = getToken(request);
+      Cookie cookie = createCookie(idToken);
+
+      response.addCookie(cookie);
+      
+      return "success"; 
+  }
+
+  private Cookie createCookie(String idToken) throws FirebaseAuthException{
+    long expiresIn = TimeUnit.HOURS.toMillis(12);
+
+    SessionCookieOptions options = SessionCookieOptions.builder()
+        .setExpiresIn(expiresIn)
+          .build(); 
+
+    String sessionCookie = FirebaseAuth.getInstance().createSessionCookie(idToken, options);
+
+    Cookie cookie = new Cookie("session", sessionCookie);
+
+    cookie.setMaxAge(43200);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(true);
+
+    return cookie;
+  } 
+
+  // リクエストヘッダからトークンを取得
+  private String getToken(HttpServletRequest request) {
+    String token = request.getHeader("Authorization");
+
+    if (token == null || !token.startsWith("Bearer ")) {
+      return null;
+    }
+
+    return token.substring("Bearer ".length());
+  }
+}
+

--- a/src/main/java/com/example/nakayoshi/NakayoshiApplication.java
+++ b/src/main/java/com/example/nakayoshi/NakayoshiApplication.java
@@ -1,13 +1,29 @@
 package com.example.nakayoshi;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 
 @SpringBootApplication
 public class NakayoshiApplication {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
+		FileInputStream serviceAccount = new FileInputStream(Paths.get("").toAbsolutePath() + "\\src\\config\\serviceAccountKey.json");
+
+		FirebaseOptions options = FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+					.setDatabaseUrl("https://<DATABASE_NAME>.firebaseio.com/")
+						.build();
+
+		FirebaseApp.initializeApp(options);
+
 		SpringApplication.run(NakayoshiApplication.class, args);
 	}
-
 }

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -12,15 +12,12 @@ class Index {
 
     firebase.initializeApp(config);
 
-    // FirebaseUIインスタンス初期化
     var ui = new firebaseui.auth.AuthUI(firebase.auth());
 
     // FirebaseUIの各種設定
     var uiConfig = {
       callbacks: {
         signInSuccessWithAuthResult: function () {
-          // サインイン成功時のコールバック関数
-          // 戻り値で自動的にリダイレクトするかどうかを指定
           firebase.auth().currentUser.getIdToken(true)
             .then(idToken => {
               axios.get('/auth', {
@@ -38,22 +35,16 @@ class Index {
           return false;
         },
         uiShown: function () {
-          // FirebaseUIウィジェット描画完了時のコールバック関数
-          // 読込中で表示しているローダー要素を消す
           document.getElementById('loader').style.display = 'none';
         }
       },
       signInOptions: [{
-          // サポートするプロバイダを指定
           provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
-          //未登録メールでの新規登録禁止
           disableSignUp: {status:true}
         }
       ],
-      //アカウント選択を行う画面の防止
       credentialHelper: firebaseui.auth.CredentialHelper.NONE,
     };
-    // FirebaseUI描画開始
     ui.start('#firebaseui-auth-container', uiConfig);
   }
 }

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -1,0 +1,59 @@
+class Index {
+
+  static init() {
+    const config = {
+      apiKey: "AIzaSyDO1OsQp21pKGqR24lvAzdh3hA1P9yTn6U",
+      authDomain: "teamnakayoshi.firebaseapp.com",
+      projectId: "teamnakayoshi",
+      storageBucket: "teamnakayoshi.appspot.com",
+      messagingSenderId: "211099684937",
+      appId: "1:211099684937:web:efa22e75696df663952f98"
+    };
+
+    firebase.initializeApp(config);
+
+    // FirebaseUIインスタンス初期化
+    var ui = new firebaseui.auth.AuthUI(firebase.auth());
+
+    // FirebaseUIの各種設定
+    var uiConfig = {
+      callbacks: {
+        signInSuccessWithAuthResult: function () {
+          // サインイン成功時のコールバック関数
+          // 戻り値で自動的にリダイレクトするかどうかを指定
+          firebase.auth().currentUser.getIdToken(true)
+            .then(idToken => {
+              axios.get('/auth', {
+                headers: {
+                  Authorization: `Bearer ${idToken}`,
+                }
+              }).then(res => {
+                  window.location.href = '/main' 
+                }
+              ).catch(res => {
+                  window.location.href = '/error' 
+              })
+            }
+          )
+          return false;
+        },
+        uiShown: function () {
+          // FirebaseUIウィジェット描画完了時のコールバック関数
+          // 読込中で表示しているローダー要素を消す
+          document.getElementById('loader').style.display = 'none';
+        }
+      },
+      signInOptions: [{
+          // サポートするプロバイダを指定
+          provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
+          //未登録メールでの新規登録禁止
+          disableSignUp: {status:true}
+        }
+      ],
+      //アカウント選択を行う画面の防止
+      credentialHelper: firebaseui.auth.CredentialHelper.NONE,
+    };
+    // FirebaseUI描画開始
+    ui.start('#firebaseui-auth-container', uiConfig);
+  }
+}

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Error Page</title>
+  </head>
+  <body>
+    <p>エラーが発生しています。</p>
+    <p>再度ログインし直してください。</p><a href="/login">ログインはこちら</a>
+  </body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>ログイン</title>
+    
+    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.8.3/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/ui/4.8.0/firebase-ui-auth__ja.js"></script>
+    
+    <script src="/js/login.js"></script>
+    <script>Index.init()</script>
+
+    <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.8.0/firebase-ui-auth.css" />
+  </head>
+
+  <body>
+    <div id="firebaseui-auth-container"></div>
+    <div id="loader">Loading...</div>
+  </body>
+
+</html>


### PR DESCRIPTION
## やること
- ログイン画面を作成する
- 利用者ページの認可機能を作成する

## やったこと
- [x] ログイン画面
- [x] Firebase SDKによるログイン処理
- [x] ログイン用コントローラー
- [x] ログイントークン受け取りとセッショントークン生成用のAPI
- [x] 利用者ページ認可用のフィルター
- [x] エラー画面

## やらないこと
- 認可が必要なページのフィルター追加はページが完成してきてから